### PR TITLE
Fix to throwing exception for successful transaction

### DIFF
--- a/PHP/BluePay.php
+++ b/PHP/BluePay.php
@@ -889,8 +889,8 @@ class BluePay {
 
     protected function parseResponse() {
         parse_str($this->response, $output);
-        $this->status = isset($output['Result']) ? $output['Result'] : null;
-        $this->message = isset($output['MESSAGE']) ? $output['MESSAGE'] : null;
+        $this->status = isset($output['Result']) ? trim($output['Result']) : null;
+        $this->message = isset($output['MESSAGE']) ? trim($output['MESSAGE']) : null;
         $this->transID = isset($output['RRNO']) ? $output['RRNO'] : null;
         $this->maskedAccount = isset($output['PAYMENT_ACCOUNT']) ? $output['PAYMENT_ACCOUNT'] : null;
         $this->cardType = isset($output['CARD_TYPE']) ? $output['CARD_TYPE'] : null;


### PR DESCRIPTION
We've had issues in production when capturing transaction for an authorized token the transaction was successful however the `isSuccessfulResponse` returned false. After bunch of logging we found that BluePay API was sending status value as `APPROVED\r`. Because of appended character `\r`, method `isSuccessfulResponse` was returning false.

So to fix that I've trimmed the status and message values before.