### PR TITLE
Fix random exception being thrown for Approved Transactions

### DIFF
--- a/PHP/BluePay.php
+++ b/PHP/BluePay.php
@@ -928,7 +928,7 @@ class BluePay {
                 $headers = explode("\n", $headers);
                 foreach($headers as $header) {
                     if (stripos($header, 'Location:') !== false) {
-                        $this->response = $header;
+                        $this->response = substr($header, strrpos($header, '/') + 1);
                     }
                 }
             } else {


### PR DESCRIPTION
The bluepay transaction call is throwing random error even when the Transactions are successful. This happens only when the API response has `Result` variable at first place in the URL parameter like `Location: /interfaces/wlcatch?Result=APPROVED&CVV2=_&TRANSACTION_TYPE=SALE&....`. So when `parse_str` in `parseResponse` tries to parse the URL parameters then it parses the key string for `Result` variable as `Location: /interfaces/wlcatch?Result => APPROVED` instead of `Result => APPROVED`. 

In fact, because of this bug any variable that appears after `?` was not getting parsed and thus it'll throw random errors like null transaction Id.

Fix: So the fix is to remove the string `Location: /interfaces/wlcatch?` before $header value is assigned to `$this->response`.