### PR TITLE
Trim whitespace before parsing response string

### DIFF
--- a/PHP/BluePay.php
+++ b/PHP/BluePay.php
@@ -940,7 +940,7 @@ class BluePay {
         } // end Process function
 
     protected function parseResponse() {
-        parse_str($this->response, $output);
+        parse_str(trim($this->response), $output);
         $this->status = isset($output['Result']) ? $output['Result'] : null;
         $this->message = isset($output['MESSAGE']) ? $output['MESSAGE'] : null;
         $this->transID = isset($output['RRNO']) ? $output['RRNO'] : null;


### PR DESCRIPTION
This fixes a bug where the response string could have whitespace/newline characters are the end, we had it occur on the bp10emu endpoint.  The problem with that is when you do `$bluePay->isSuccessfulResponse()` it will return `false` if the response has the `Result=APPROVED` at the end and also has whitespace (or new line).

By trimming the response before you parse it, it eliminates the bug.